### PR TITLE
Harmonized null handling of Maybe.IEnumerable with the rest of monads.net

### DIFF
--- a/Src/Monads/Maybe.IEnumerable.cs
+++ b/Src/Monads/Maybe.IEnumerable.cs
@@ -18,7 +18,10 @@ namespace System.Monads
 			{
 				foreach (var element in source)
 				{
-					action(element);
+					if (element != null)
+					{
+						action(element);
+					}
 				}
 			}
 
@@ -33,12 +36,16 @@ namespace System.Monads
 		/// <param name="action">Action which should to do</param>
 		/// <returns>Source collection</returns>
 		public static IEnumerable<TSource> Do<TSource>(this IEnumerable<TSource> source, Action<TSource> action)
+			where TSource : class
 		{
 			if (source != null)
 			{
 				foreach (var element in source)
 				{
-					action(element);
+					if (element != null)
+					{
+						action(element);
+					}
 				}
 			}
 
@@ -53,12 +60,18 @@ namespace System.Monads
 		/// <param name="action">Action which should to do (with zero-based index)</param>
 		/// <returns>Source collection</returns>
 		public static IEnumerable<TSource> Do<TSource>(this IEnumerable<TSource> source, Action<TSource, int> action)
+			where TSource : class
 		{
 			if (source != null)
 			{
-				foreach (var element in source.Select((s, i) => new { Source = s, Index = i }))
+				var iter = -1;
+				foreach (var element in source)
 				{
-					action(element.Source, element.Index);
+					++iter;
+					if (element != null)
+					{
+						action(element, iter);
+					}
 				}
 			}
 
@@ -74,14 +87,156 @@ namespace System.Monads
 		/// <param name="action">Action which should to do</param>
 		/// <returns>Converted collection</returns>
 		public static IEnumerable<TResult> With<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> action)
+			where TSource : class
 		{
 			if (source != null)
 			{
-				return source.Select(action);
+				foreach (var element in source)
+				{
+					if (element != null)
+					{
+						yield return action(element);
+					}
+					else
+					{
+						yield return default (TResult);
+					}
+				}
 			}
-			else
+		}
+
+		/// <summary>
+		/// Allows to do some conversion of <paramref name="source"/> collection elements if its not null
+		/// </summary>
+		/// <typeparam name="TSource">Type of collection elements</typeparam>
+		/// <typeparam name="TResult">Type of result collection elements</typeparam>
+		/// <param name="source">Source collection for operating</param>
+		/// <param name="action">Action which should to do (with zero-based index)</param>
+		/// <returns>Converted collection</returns>
+		public static IEnumerable<TResult> With<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, int, TResult> action)
+			where TSource : class
+		{
+			if (source != null)
 			{
-				return null;
+				var iter = -1;
+				foreach (var element in source)
+				{
+					++iter;
+					if (element != null)
+					{
+						yield return action(element, iter);
+					}
+					else
+					{
+						yield return default (TResult);
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Allows to do some <paramref name="action"/> on each element of <paramref name="source"/>
+		/// </summary>
+		/// <typeparam name="TSource">Type of collection elements</typeparam>
+		/// <param name="source">Source collection for operating</param>
+		/// <param name="action">Action which should to do</param>
+		/// <returns>Source collection</returns>
+		public static IEnumerable<TSource?> Do<TSource>(this IEnumerable<TSource?> source, Action<TSource> action)
+			where TSource : struct
+		{
+			if (source != null)
+			{
+				foreach (var element in source)
+				{
+					if (element != null)
+					{
+						action(element.Value);
+					}
+				}
+			}
+
+			return source;
+		}
+
+		/// <summary>
+		/// Allows to do some <paramref name="action"/> on each element of <paramref name="source"/>
+		/// </summary>
+		/// <typeparam name="TSource">Type of collection elements</typeparam>
+		/// <param name="source">Source collection for operating</param>
+		/// <param name="action">Action which should to do (with zero-based index)</param>
+		/// <returns>Source collection</returns>
+		public static IEnumerable<TSource?> Do<TSource>(this IEnumerable<TSource?> source, Action<TSource, int> action)
+			where TSource : struct
+		{
+			if (source != null)
+			{
+				var iter = -1;
+				foreach (var element in source)
+				{
+					++iter;
+					if (element != null)
+					{
+						action(element.Value, iter);
+					}
+				}
+			}
+
+			return source;
+		}
+
+		/// <summary>
+		/// Allows to do some conversion of <paramref name="source"/> collection elements if its not null
+		/// </summary>
+		/// <typeparam name="TSource">Type of collection elements</typeparam>
+		/// <typeparam name="TResult">Type of result collection elements</typeparam>
+		/// <param name="source">Source collection for operating</param>
+		/// <param name="action">Action which should to do</param>
+		/// <returns>Converted collection</returns>
+		public static IEnumerable<TResult> With<TSource, TResult>(this IEnumerable<TSource?> source, Func<TSource, TResult> action)
+			where TSource : struct
+		{
+			if (source != null)
+			{
+				foreach (var element in source)
+				{
+					if (element != null)
+					{
+						yield return action(element.Value);
+					}
+					else
+					{
+						yield return default (TResult);
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Allows to do some conversion of <paramref name="source"/> collection elements if its not null
+		/// </summary>
+		/// <typeparam name="TSource">Type of collection elements</typeparam>
+		/// <typeparam name="TResult">Type of result collection elements</typeparam>
+		/// <param name="source">Source collection for operating</param>
+		/// <param name="action">Action which should to do (with zero-based index)</param>
+		/// <returns>Converted collection</returns>
+		public static IEnumerable<TResult> With<TSource, TResult>(this IEnumerable<TSource?> source, Func<TSource, int, TResult> action)
+			where TSource : struct
+		{
+			if (source != null)
+			{
+				var iter = -1;
+				foreach (var element in source)
+				{
+					++iter;
+					if (element != null)
+					{
+						yield return action(element.Value, iter);
+					}
+					else
+					{
+						yield return default (TResult);
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hi there.

I was thinking abit over how monads.net works for objects and IEnumerable. IMHO in my mind it makes more sense if the extension methods for IEnumerable check each object in the collection for null and applies the action if not null, otherwise skip.

This makes for more null-safe code as well as avoiding irritating null reference exceptions and IMHO is more in spirit with the rest of monads.net.

Of course you are free to disagree with all of this and deny the pullrequest.

.With with key for IDictionary is a gem!

Best regards,
Mårten
