### PR TITLE
Nullable

### DIFF
--- a/Src/Monads.Tests/MaybeNullableTests.cs
+++ b/Src/Monads.Tests/MaybeNullableTests.cs
@@ -11,7 +11,7 @@ namespace System.Monads.Tests
 			int? source = 5;
 
 			var result = 0;
-			source.Do(s => result = s.Value);
+			source.Do(s => result = s);
 
 			Assert.AreEqual(5, result);
 		}
@@ -22,7 +22,7 @@ namespace System.Monads.Tests
 			int? source = null;
 
 			var result = 10;
-			source.Do(s => result = s.Value);
+			source.Do(s => result = s);
 
 			Assert.AreEqual(10, result);
 		}
@@ -32,7 +32,11 @@ namespace System.Monads.Tests
 		{
 			int? source = 5;
 
-			int result = source.With(s => s.Value);
+			//int result = source.With(s => s);
+			//error CS0121: The call is ambiguous between the following methods or properties:
+			//'System.Monads.MaybeNullable.With<int,int>(int?, System.Func<int,int>)' and 'System.Monads.MaybeObjects.With<int?,int?>(int?, System.Func<int?,int?>)'
+
+			int result = source.With((int s) => s);
 
 			Assert.AreEqual(5, result);
 		}
@@ -42,7 +46,7 @@ namespace System.Monads.Tests
 		{
 			int? source = null;
 
-			int result = source.With(s => s.Value);
+			int result = source.With((int s) => s);
 
 			Assert.AreEqual(default(int), result);
 		}
@@ -52,7 +56,7 @@ namespace System.Monads.Tests
 		{
 			int? source = 5;
 
-			int result = source.Return(s => s.Value, 10);
+			int result = source.Return(s => s, 10);
 
 			Assert.AreEqual(5, result);
 		}
@@ -62,7 +66,7 @@ namespace System.Monads.Tests
 		{
 			int? source = null;
 
-			int result = source.Return(s => s.Value, 10);
+			int result = source.Return(s => s, 10);
 
 			Assert.AreEqual(10, result);
 		}
@@ -72,8 +76,8 @@ namespace System.Monads.Tests
 		{
 			int? source = 5;
 
-			Assert.AreEqual(source, source.If(s => s.Value > 3));
-			Assert.AreEqual(default(int), source.If(s => s.Value > 6));
+			Assert.AreEqual(5, source.If((int s) => s > 3));
+			Assert.AreEqual(default(int), source.If((int s) => s > 6));
 		}
 
 		[TestMethod]
@@ -81,8 +85,8 @@ namespace System.Monads.Tests
 		{
 			int? source = null;
 
-			Assert.AreEqual(default(int), source.If(s => s.Value > 3));
-			Assert.AreEqual(default(int), source.If(s => s.Value > 6));
+			Assert.AreEqual(default(int), source.If((int s) => s > 3));
+			Assert.AreEqual(default(int), source.If((int s) => s > 6));
 		}
 
 		[TestMethod]
@@ -90,8 +94,8 @@ namespace System.Monads.Tests
 		{
 			int? source = 5;
 
-			Assert.AreEqual(default(int), source.IfNot(s => s.Value > 3));
-			Assert.AreEqual(source, source.IfNot(s => s.Value > 6));
+			Assert.AreEqual(default(int), source.IfNot((int s) => s > 3));
+			Assert.AreEqual(source, source.IfNot((int s) => s > 6));
 		}
 
 		[TestMethod]
@@ -99,8 +103,8 @@ namespace System.Monads.Tests
 		{
 			int? source = null;
 
-			Assert.AreEqual(default(int), source.IfNot(s => s.Value > 3));
-			Assert.AreEqual(default(int), source.IfNot(s => s.Value > 6));
+			Assert.AreEqual(default(int), source.IfNot((int s) => s > 3));
+			Assert.AreEqual(default(int), source.IfNot((int s) => s > 6));
 		}
 
 		[TestMethod]
@@ -119,7 +123,7 @@ namespace System.Monads.Tests
 			int? source = 5;
 
 			var r = 0;
-			var result = source.TryDo(s => r = s.Value);
+			var result = source.TryDo(s => r = s);
 
 			Assert.AreEqual(5, r);
 			Assert.AreEqual(source, result.Item1);
@@ -132,7 +136,7 @@ namespace System.Monads.Tests
 			int? source = null;
 
 			var r = 10;
-			var result = source.TryDo(s => r = s.Value);
+			var result = source.TryDo(s => r = s);
 
 			Assert.AreEqual(10, r);
 			Assert.AreEqual(null, result.Item1);
@@ -144,10 +148,10 @@ namespace System.Monads.Tests
 		{
 			int? source = 1;
 
-			var r = String.Empty;
-			var result = source.TryDo(s => r = (100 / (s - 1)).ToString());
+			var r = 10;
+			var result = source.TryDo(s => r = (100 / (s - 1)));
 
-			Assert.AreEqual(String.Empty, r);
+			Assert.AreEqual(10, r);
 			Assert.AreEqual(source, result.Item1);
 			Assert.IsInstanceOfType(result.Item2, typeof(DivideByZeroException));
 		}
@@ -157,7 +161,8 @@ namespace System.Monads.Tests
 		{
 			int? source = 1;
 
-			var result = source.TryDo(s => (100 / (s - 1)).ToString(), ex => ex is DivideByZeroException);
+			var r = 10;
+			var result = source.TryDo(s => r = (100 / (s - 1)), ex => ex is DivideByZeroException);
 
 			Assert.AreEqual(source, result.Item1);
 			Assert.IsInstanceOfType(result.Item2, typeof(DivideByZeroException));
@@ -168,7 +173,8 @@ namespace System.Monads.Tests
 		{
 			int? source = 1;
 
-			var result = source.TryDo(s => (100 / (s - 1)).ToString(), typeof(DivideByZeroException), typeof(ArgumentException));
+			var r = 10;
+			var result = source.TryDo(s => r = (100 / (s - 1)), typeof(DivideByZeroException), typeof(ArgumentException));
 
 			Assert.AreEqual(source, result.Item1);
 			Assert.IsInstanceOfType(result.Item2, typeof(DivideByZeroException));
@@ -181,7 +187,8 @@ namespace System.Monads.Tests
 			{
 				int? source = 1;
 
-				var result = source.TryDo(s => (100 / (s - 1)).ToString(), typeof(OutOfMemoryException), typeof(ArgumentException));
+				var r = 10;
+				var result = source.TryDo(s => r = (100 / (s - 1)), typeof(OutOfMemoryException), typeof(ArgumentException));
 
 				Assert.Fail("Exception must be thrown.");
 			}
@@ -195,7 +202,7 @@ namespace System.Monads.Tests
 		{
 			int? source = 5;
 
-			Tuple<int,Exception> result = source.TryWith(s => s.Value);
+			Tuple<int,Exception> result = source.TryWith((int s) => s);
 
 			Assert.AreEqual(5, result.Item1);
 			Assert.AreEqual(null, result.Item2);
@@ -206,7 +213,7 @@ namespace System.Monads.Tests
 		{
 			int? source = null;
 
-			Tuple<int, Exception> result = source.TryWith(s => s.Value);
+			Tuple<int, Exception> result = source.TryWith((int s) => s);
 
 			Assert.AreEqual(default(int), result.Item1);
 			Assert.AreEqual(null, result.Item2);
@@ -218,9 +225,9 @@ namespace System.Monads.Tests
 		{
 			int? source = 1;
 
-			var result = source.TryWith(s => (100 / (s - 1)).ToString());
+			var result = source.TryWith((int s) => (100 / (s - 1)));
 
-			Assert.AreEqual(null, result.Item1);
+			Assert.AreEqual(default(int), result.Item1);
 			Assert.IsInstanceOfType(result.Item2, typeof(DivideByZeroException));
 		}
 
@@ -229,9 +236,9 @@ namespace System.Monads.Tests
 		{
 			int? source = 1;
 
-			var result = source.TryWith(s => (100 / (s - 1)).ToString(), ex => ex is DivideByZeroException);
+			var result = source.TryWith((int s) => (100 / (s - 1)), ex => ex is DivideByZeroException);
 
-			Assert.AreEqual(null, result.Item1);
+			Assert.AreEqual(default(int), result.Item1);
 			Assert.IsInstanceOfType(result.Item2, typeof(DivideByZeroException));
 		}
 
@@ -240,9 +247,9 @@ namespace System.Monads.Tests
 		{
 			int? source = 1;
 
-			var result = source.TryWith(s => (100 / (s - 1)).ToString(), typeof(DivideByZeroException));
+			var result = source.TryWith((int s) => (100 / (s - 1)), typeof(DivideByZeroException));
 
-			Assert.AreEqual(null, result.Item1);
+			Assert.AreEqual(default(int), result.Item1);
 			Assert.IsInstanceOfType(result.Item2, typeof(DivideByZeroException));
 		}
 
@@ -253,7 +260,7 @@ namespace System.Monads.Tests
 			{
 				int? source = 1;
 
-				var result = source.TryWith(s => (100 / (s - 1)).ToString(), typeof(OutOfMemoryException));
+				var result = source.TryWith((int s) => (100 / (s - 1)), typeof(OutOfMemoryException));
 
 				Assert.Fail("Exception must be thrown.");
 			}

--- a/Src/Monads.Tests/MaybeNullableTests.cs
+++ b/Src/Monads.Tests/MaybeNullableTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace System.Monads.Tests
 {
@@ -11,10 +10,10 @@ namespace System.Monads.Tests
 		{
 			int? source = 5;
 
-			var result = String.Empty;
-			source.Do(s => result = s.ToString());
+			var result = 0;
+			source.Do(s => result = s.Value);
 
-			Assert.AreEqual("5", result);
+			Assert.AreEqual(5, result);
 		}
 
 		[TestMethod]
@@ -22,10 +21,10 @@ namespace System.Monads.Tests
 		{
 			int? source = null;
 
-			var result = String.Empty;
-			source.Do(s => result = s.ToString());
+			var result = 10;
+			source.Do(s => result = s.Value);
 
-			Assert.AreEqual(String.Empty, result);
+			Assert.AreEqual(10, result);
 		}
 
 		[TestMethod]
@@ -33,9 +32,9 @@ namespace System.Monads.Tests
 		{
 			int? source = 5;
 
-			var result = source.With(s => s.ToString());
+			int result = source.With(s => s.Value);
 
-			Assert.AreEqual("5", result);
+			Assert.AreEqual(5, result);
 		}
 
 		[TestMethod]
@@ -43,9 +42,9 @@ namespace System.Monads.Tests
 		{
 			int? source = null;
 
-			var result = source.With(s => s.ToString());
+			int result = source.With(s => s.Value);
 
-			Assert.AreEqual(default(string), result);
+			Assert.AreEqual(default(int), result);
 		}
 
 		[TestMethod]
@@ -53,9 +52,9 @@ namespace System.Monads.Tests
 		{
 			int? source = 5;
 
-			var result = source.Return(s => s.ToString(), "Nothing");
+			int result = source.Return(s => s.Value, 10);
 
-			Assert.AreEqual("5", result);
+			Assert.AreEqual(5, result);
 		}
 
 		[TestMethod]
@@ -63,9 +62,9 @@ namespace System.Monads.Tests
 		{
 			int? source = null;
 
-			var result = source.Return(s => s.ToString(), "Nothing");
+			int result = source.Return(s => s.Value, 10);
 
-			Assert.AreEqual("Nothing", result);
+			Assert.AreEqual(10, result);
 		}
 
 		[TestMethod]
@@ -109,7 +108,7 @@ namespace System.Monads.Tests
 		{
 			int? source = null;
 
-			var result = source.Recover(() => 10);
+			int result = source.Recover(() => 10);
 
 			Assert.AreEqual(10, result);
 		}
@@ -119,10 +118,10 @@ namespace System.Monads.Tests
 		{
 			int? source = 5;
 
-			var r = String.Empty;
-			var result = source.TryDo(s => r = s.ToString());
+			var r = 0;
+			var result = source.TryDo(s => r = s.Value);
 
-			Assert.AreEqual("5", r);
+			Assert.AreEqual(5, r);
 			Assert.AreEqual(source, result.Item1);
 			Assert.AreEqual(null, result.Item2);
 		}
@@ -132,10 +131,10 @@ namespace System.Monads.Tests
 		{
 			int? source = null;
 
-			var r = String.Empty;
-			var result = source.TryDo(s => r = s.ToString());
+			var r = 10;
+			var result = source.TryDo(s => r = s.Value);
 
-			Assert.AreEqual(String.Empty, r);
+			Assert.AreEqual(10, r);
 			Assert.AreEqual(null, result.Item1);
 			Assert.AreEqual(null, result.Item2);
 		}
@@ -189,6 +188,28 @@ namespace System.Monads.Tests
 			catch (DivideByZeroException)
 			{
 			}
+		}
+
+		[TestMethod]
+		public void TryWithOnObjectWithValueNoException()
+		{
+			int? source = 5;
+
+			Tuple<int,Exception> result = source.TryWith(s => s.Value);
+
+			Assert.AreEqual(5, result.Item1);
+			Assert.AreEqual(null, result.Item2);
+		}
+
+		[TestMethod]
+		public void TryWithOnObjectWithNullNoException()
+		{
+			int? source = null;
+
+			Tuple<int, Exception> result = source.TryWith(s => s.Value);
+
+			Assert.AreEqual(default(int), result.Item1);
+			Assert.AreEqual(null, result.Item2);
 		}
 
 

--- a/Src/Monads.Tests/MaybeNullableTests.cs
+++ b/Src/Monads.Tests/MaybeNullableTests.cs
@@ -6,6 +6,18 @@ namespace System.Monads.Tests
 	public class MaybeNullableTests
 	{
 		[TestMethod]
+		public void WithOnDateTime()
+		{
+			DateTime? source = new DateTime(2014, 9, 1);
+
+			//please note that explicit type specification is not needed
+			int result = source.With(s => s.Day);
+
+			Assert.AreEqual(1, result);
+		}
+
+	
+		[TestMethod]
 		public void DoOnObjectWithValue()
 		{
 			int? source = 5;

--- a/Src/Monads/Maybe.Nullable.cs
+++ b/Src/Monads/Maybe.Nullable.cs
@@ -11,12 +11,12 @@ namespace System.Monads
 		/// <param name="source">Source object for operating</param>
 		/// <param name="action">Action which should to do</param>
 		/// <returns><paramref name="source"/> object</returns>
-		public static Nullable<TSource> Do<TSource>(this Nullable<TSource> source, Action<Nullable<TSource>> action)
+		public static Nullable<TSource> Do<TSource>(this Nullable<TSource> source, Action<TSource> action)
 			where TSource : struct
 		{
 			if (source.HasValue == true)
 			{
-				action(source);
+				action(source.GetValueOrDefault());
 			}
 
 			return source;
@@ -30,12 +30,12 @@ namespace System.Monads
 		/// <param name="source">Source object for operating</param>
 		/// <param name="action">Conversion action which should to do</param>
 		/// <returns>Converted object which returns action</returns>
-		public static TResult With<TSource, TResult>(this Nullable<TSource> source, Func<Nullable<TSource>, TResult> action)
+		public static TResult With<TSource, TResult>(this Nullable<TSource> source, Func<TSource, TResult> action)
 			where TSource : struct
 		{
 			if (source.HasValue == true)
 			{
-				return action(source);
+				return action(source.GetValueOrDefault());
 			}
 			else
 			{
@@ -52,12 +52,12 @@ namespace System.Monads
 		/// <param name="action">Conversion action which should to do</param>
 		/// <param name="defaultValue">Value which will return if source is null</param>
 		/// <returns>Converted object which returns action if source is not null or <paramref name="defaultValue"/> otherwise</returns>
-		public static TResult Return<TSource, TResult>(this Nullable<TSource> source, Func<Nullable<TSource>, TResult> action, TResult defaultValue)
+		public static TResult Return<TSource, TResult>(this Nullable<TSource> source, Func<TSource, TResult> action, TResult defaultValue)
 			where TSource : struct
 		{
 			if (source.HasValue == true)
 			{
-				return action(source);
+				return action(source.GetValueOrDefault());
 			}
 			else
 			{
@@ -66,18 +66,18 @@ namespace System.Monads
 		}
 
 		/// <summary>
-		/// Retruns the <paramref name="source"/> if both <paramref name="condition"/> is true and <paramref name="source"/> is not null, or null otherwise
+		/// Retruns the <paramref name="source"/> if both <paramref name="condition"/> is true and <paramref name="source"/> is not null, or <c>default(TSource)</c> otherwise
 		/// </summary>
 		/// <typeparam name="TSource">Type of source object</typeparam>
 		/// <param name="source">Source object for operating</param>
 		/// <param name="condition">Condition which should be checked</param>
-		/// <returns><paramref name="source"/> if <paramref name="condition"/> is true, or null otherwise</returns>
-		public static Nullable<TSource> If<TSource>(this Nullable<TSource> source, Func<Nullable<TSource>, bool> condition)
+		/// <returns><paramref name="source"/> if <paramref name="condition"/> is true, or <c>default(TSource)</c> otherwise</returns>
+		public static TSource If<TSource>(this Nullable<TSource> source, Func<TSource, bool> condition)
 			where TSource : struct
 		{
-			if ((source.HasValue == true) && (condition(source) == true))
+			if ((source.HasValue == true) && (condition(source.GetValueOrDefault()) == true))
 			{
-				return source;
+				return source.GetValueOrDefault();
 			}
 			else
 			{
@@ -86,18 +86,18 @@ namespace System.Monads
 		}
 
 		/// <summary>
-		/// Retruns the <paramref name="source"/> if both <paramref name="condition"/> is false and <paramref name="source"/> is not null, or null otherwise
+		/// Retruns the <paramref name="source"/> if both <paramref name="condition"/> is false and <paramref name="source"/> is not null, or <c>default(TSource)</c> otherwise
 		/// </summary>
 		/// <typeparam name="TSource">Type of source object</typeparam>
 		/// <param name="source">Source object for operating</param>
 		/// <param name="condition">Condition which should be checked</param>
-		/// <returns><paramref name="source"/> if <paramref name="condition"/> is true, or null otherwise</returns>
-		public static Nullable<TSource> IfNot<TSource>(this Nullable<TSource> source, Func<Nullable<TSource>, bool> condition)
+		/// <returns><paramref name="source"/> if <paramref name="condition"/> is true, or <c>default(TSource)</c> otherwise</returns>
+		public static TSource IfNot<TSource>(this Nullable<TSource> source, Func<TSource, bool> condition)
 			where TSource : struct
 		{
-			if ((source.HasValue == true) && (condition(source) == false))
+			if ((source.HasValue == true) && (condition(source.GetValueOrDefault()) == false))
 			{
-				return source;
+				return source.GetValueOrDefault();
 			}
 			else
 			{
@@ -115,7 +115,7 @@ namespace System.Monads
 		public static TInput Recover<TInput>(this Nullable<TInput> source, Func<TInput> action)
 			where TInput : struct
 		{
-			return source.HasValue == true ? source.Value : action();
+			return source.HasValue == true ? source.GetValueOrDefault() : action();
 		}
 
 		/// <summary>
@@ -127,14 +127,14 @@ namespace System.Monads
 		/// <returns>
 		/// Tuple which contains <paramref name="source"/> and info about exception (if it throws)
 		/// </returns>
-		public static Tuple<Nullable<TSource>, Exception> TryDo<TSource>(this Nullable<TSource> source, Action<Nullable<TSource>> action)
+		public static Tuple<Nullable<TSource>, Exception> TryDo<TSource>(this Nullable<TSource> source, Action<TSource> action)
 			where TSource : struct
 		{
 			if (source.HasValue == true)
 			{
 				try
 				{
-					action(source);
+					action(source.GetValueOrDefault());
 				}
 				catch (Exception ex)
 				{
@@ -155,14 +155,14 @@ namespace System.Monads
 		/// <returns>
 		/// Tuple which contains <paramref name="source"/> and info about exception (if it throws)
 		/// </returns>
-		public static Tuple<Nullable<TSource>, Exception> TryDo<TSource>(this Nullable<TSource> source, Action<Nullable<TSource>> action, Func<Exception, bool> exceptionChecker)
+		public static Tuple<Nullable<TSource>, Exception> TryDo<TSource>(this Nullable<TSource> source, Action<TSource> action, Func<Exception, bool> exceptionChecker)
 			where TSource : struct
 		{
 			if (source.HasValue == true)
 			{
 				try
 				{
-					action(source);
+					action(source.GetValueOrDefault());
 				}
 				catch (Exception ex)
 				{
@@ -190,14 +190,14 @@ namespace System.Monads
 		/// <returns>
 		/// Tuple which contains <paramref name="source"/> and info about exception (if it throws)
 		/// </returns>
-		public static Tuple<Nullable<TSource>, Exception> TryDo<TSource>(this Nullable<TSource> source, Action<Nullable<TSource>> action, params Type[] expectedException)
+		public static Tuple<Nullable<TSource>, Exception> TryDo<TSource>(this Nullable<TSource> source, Action<TSource> action, params Type[] expectedException)
 			where TSource : struct
 		{
 			if (source.HasValue == true)
 			{
 				try
 				{
-					action(source);
+					action(source.GetValueOrDefault());
 				}
 				catch (Exception ex)
 				{
@@ -224,7 +224,7 @@ namespace System.Monads
 		/// <param name="source">Source object for operating</param>
 		/// <param name="action">Action which should to do</param>
 		/// <returns>Tuple which contains Converted object and info about exception (if it throws)</returns>
-		public static Tuple<TResult, Exception> TryWith<TSource, TResult>(this Nullable<TSource> source, Func<Nullable<TSource>, TResult> action)
+		public static Tuple<TResult, Exception> TryWith<TSource, TResult>(this Nullable<TSource> source, Func<TSource, TResult> action)
 			where TSource : struct
 		{
 			if (source.HasValue == true)
@@ -232,7 +232,7 @@ namespace System.Monads
 				TResult result = default(TResult);
 				try
 				{
-					result = action(source);
+					result = action(source.GetValueOrDefault());
 					return new Tuple<TResult, Exception>(result, null);
 				}
 				catch (Exception ex)
@@ -253,7 +253,7 @@ namespace System.Monads
 		/// <param name="action">Action which should to do</param>
 		/// <param name="exceptionChecker">Predicate to determine if exceptions should be handled</param>
 		/// <returns>Tuple which contains Converted object and info about exception (if it throws)</returns>
-		public static Tuple<TResult, Exception> TryWith<TSource, TResult>(this Nullable<TSource> source, Func<Nullable<TSource>, TResult> action, Func<Exception, bool> exceptionChecker)
+		public static Tuple<TResult, Exception> TryWith<TSource, TResult>(this Nullable<TSource> source, Func<TSource, TResult> action, Func<Exception, bool> exceptionChecker)
 			where TSource : struct
 		{
 			if (source.HasValue == true)
@@ -261,7 +261,7 @@ namespace System.Monads
 				TResult result = default(TResult);
 				try
 				{
-					result = action(source);
+					result = action(source.GetValueOrDefault());
 					return new Tuple<TResult, Exception>(result, null);
 				}
 				catch (Exception ex)
@@ -289,7 +289,7 @@ namespace System.Monads
 		/// <param name="action">Action which should to do</param>
 		/// <param name="expectedException">Array of exception types, which should be handled</param>
 		/// <returns>Tuple which contains Converted object and info about exception (if it throws)</returns>
-		public static Tuple<TResult, Exception> TryWith<TSource, TResult>(this Nullable<TSource> source, Func<Nullable<TSource>, TResult> action, params Type[] expectedException)
+		public static Tuple<TResult, Exception> TryWith<TSource, TResult>(this Nullable<TSource> source, Func<TSource, TResult> action, params Type[] expectedException)
 			where TSource : struct
 		{
 			if (source.HasValue == true)
@@ -297,7 +297,7 @@ namespace System.Monads
 				TResult result = default(TResult);
 				try
 				{
-					result = action(source);
+					result = action(source.GetValueOrDefault());
 					return new Tuple<TResult, Exception>(result, null);
 				}
 				catch (Exception ex)


### PR DESCRIPTION
I attempted to get a better `Nullable<T>` readability from (`source` is a `Nullable<int>`):

``` c#
source.With(s => s.GetValueOrDefault() + 1); //s is Nullable<int>
```

to

``` c#
source.With(s => s + 1); //s is int
```

Unfortunately, due to C# type inference limitations the best I could get is:

``` c#
source.With((int s) => s + 1);
```

But, as could be seen in `DateTime` test, sometimes it could be avoided, leading to beautiful and pure code (`source` is a `Nullable<DateTime>`):

``` c#
int result = source.With(s => s.Day);
```

It is up to you to decide whether it's worth the effort.
