### PR TITLE
Added monads "Do" and "DoSelect" with nullaction

### DIFF
--- a/Src/Monads/Maybe.Objects.cs
+++ b/Src/Monads/Maybe.Objects.cs
@@ -21,6 +21,44 @@ namespace System.Monads
 
 			return source;
 		}
+		
+		/// <summary>
+		/// Allows to do some <paramref name="action"/> on <paramref name="source"/> when it's not null and another action when null (for example, writing logs) 
+		/// </summary>
+		/// <typeparam name="TSource">Type of source object</typeparam>
+		/// <param name="source">Source object for operating</param>
+		/// <param name="action">Action when not null</param>
+		/// <param name="nullaction">Action when null</param>
+		/// <returns><paramref name="source"/> object</returns>
+		public static TSource Do<TSource>(this TSource source, Action<TSource> action, Action<TSource> nullaction = null) where TSource : class
+	        {
+	            if (source != default(TSource))
+	                action(source);
+	            else if (nullaction != null)
+	                nullaction(source);
+	
+	            return source;
+	        }
+	        
+	        /// <summary>
+		/// Allows to do some select on <paramref name="source"/> when it's not null and another action when null (for example, writing logs) 
+		/// </summary>
+		/// <typeparam name="TSource">Type of source object</typeparam>
+		/// <param name="source">Source object for operating</param>
+		/// <param name="action">Select function when not null</param>
+		/// <param name="nullaction">Action when null</param>
+		/// <returns><paramref name="source"/> object</returns>
+	        public static TResult DoSelect<TSource, TResult>(this TSource source, Func<TSource, TResult> action, Action<TSource> nullaction = null)
+	            where TSource : class
+	            where TResult : class
+	        {
+	            if (source != default(TSource))
+	                return action(source);
+	            else if (nullaction != null)
+	                nullaction(source);
+	
+	            return default(TResult);
+	        }
 
 		/// <summary>
 		/// Allows to do some conversion of <paramref name="source"/> if its not null


### PR DESCRIPTION
Added monad "Do" with action that runs when source is null, for example for logging
Added monad "DoSelect" with null action that acts like LINQ Select clause but with additional action for nulled source.
#### Examples of using Do/DoSelect

BEFORE:

```
object o1 = entry.Value.GetType().GetProperty("Value", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(entry.Value, null);
if (o1.GetType().ToString() == "System.Web.SessionState.InProcSessionState")
{
    var sess = o1.GetType().GetField("_sessionItems", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(o1);
    if (sess != null && sess is SessionStateItemCollection) activeSessions.Add(sess);
    else 
        Logger.LogError("Get Sessions list error", "no session items exist");
}
else
    Logger.LogError("Get Sessions list error", "no session exists");
```

AFTER:

```
entry.Value.GetType().GetProperty("Value", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(entry.Value, null)
    .If(x => x.GetType().ToString() == "System.Web.SessionState.InProcSessionState")
    .DoSelect(x => x.GetType().GetField("_sessionItems", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(x), 
              _ => Logger.LogError("Get Sessions list error", "no session exists"))
    .If(x => x is SessionStateItemCollection)
    .Do(x => activeSessions.Add(x), 
        _ => Logger.LogError("Get Sessions list error", "no session items exist"));
```
